### PR TITLE
Change variable name to lower case

### DIFF
--- a/cpp/KapeDoubleFree.ql
+++ b/cpp/KapeDoubleFree.ql
@@ -15,10 +15,10 @@ predicate between(ControlFlowNode a, ControlFlowNode mid, ControlFlowNode b) {
   notThroughX(a, mid, b) and notThroughX(mid, b, a)
 }
 
-predicate notThroughX(ControlFlowNode e1, ControlFlowNode e2, ControlFlowNode X) {
+predicate notThroughX(ControlFlowNode e1, ControlFlowNode e2, ControlFlowNode x) {
   e1 = e2
   or
-  exists(ControlFlowNode cfn | cfn = e1.getASuccessor() and cfn != X and notThroughX(cfn, e2, X))
+  exists(ControlFlowNode cfn | cfn = e1.getASuccessor() and cfn != x and notThroughX(cfn, e2, x))
 }
 
 from FunctionCall fc, FunctionCall fc2, LocalScopeVariable v


### PR DESCRIPTION
Variables starting with an upper-case letter may stop working in future CodeQL versions.

To create space in the syntax for planned QL improvements, upper-case variables will become deprecated. When we've renamed all occurrences in actively-used QL code, we'll change the compiler so they no longer work.